### PR TITLE
连接池优化 & socket 事件优化

### DIFF
--- a/connection.js
+++ b/connection.js
@@ -8,7 +8,12 @@ class Connection {
   get defaultOptions() {
     return {
       keepAlive: true,
+      timeout: 60 * 1000,
     };
+  }
+
+  get destroyed() {
+    return this.socket.destroyed;
   }
 
   constructor(options = {}) {
@@ -32,6 +37,7 @@ class Connection {
 
   connect() {
     this.socket = new net.Socket();
+    this.socket.setTimeout(this.options.timeout);
     this.socket.setKeepAlive(this.options.keepAlive);
     this.socket.connect(this.options.port, this.options.host);
     this.socket.setEncoding('utf8');
@@ -108,6 +114,7 @@ class Connection {
         // Emitted if the socket times out from inactivity. This is only to notify that the socket has been idle.
         // The user must manually close the connection.
         debug('socket event -> timeout');
+        this.socket.end();
       })
       .on('drain', () => {
         // Emitted when the write buffer becomes empty. Can be used to throttle uploads.
@@ -131,9 +138,6 @@ class Connection {
         if (!this.socket.destroyed) {
           this.socket.destroy();
         }
-        setTimeout(() => {
-          this.socket.connect(this.options.port, this.options.host);
-        }, 3000);
       });
   }
 

--- a/index.js
+++ b/index.js
@@ -7,12 +7,7 @@ const userAgent = 'LightningHttpClient/0.0.1';
 class HttpRequestClient {
   constructor(options) {
     this.options = options || {};
-    this.options.poolOptions = Object.assign(
-      {
-        min: 100,
-      },
-      this.options.poolOptions || {}
-    );
+    this.options.poolOptions = Object.assign({}, this.options.poolOptions || {});
 
     const factory = {
       create: () => {

--- a/pool.js
+++ b/pool.js
@@ -1,7 +1,7 @@
 class Pool {
   get defaultOptions() {
     return {
-      min: 100,
+      initialValue: 10,
     };
   }
 
@@ -13,8 +13,8 @@ class Pool {
   }
 
   init() {
-    const min = this.options.min;
-    for (let i = 0; i < min; i++) {
+    const initialValue = this.options.initialValue;
+    for (let i = 0; i < initialValue; i++) {
       this.resources.push(this.factory.create());
     }
   }
@@ -23,7 +23,13 @@ class Pool {
     if (this.resources.length === 0) {
       return this.factory.create();
     }
-    return this.resources.pop();
+    const conn = this.resources.pop();
+    // 判断该连接是否已销毁，如果已销毁，则重新申请，直到申请到一个未销毁的连接
+    if (!conn.destroyed) {
+      return conn;
+    } else {
+      return this.acquire();
+    }
   }
 
   release(resource) {


### PR DESCRIPTION
- 连接池初始值默认设置成 10
- 申请一个连接时，首先判断是否销毁，如果已销毁，则再申请一个，直到申请到一个可用的连接
- 设置 socket timeout 为 60秒
- 当 socket 触发 timeout 事件时，调用 end 方法，关闭 socket 连接